### PR TITLE
Remove htmlspecialchars()

### DIFF
--- a/src/Login.php
+++ b/src/Login.php
@@ -16,7 +16,7 @@ class Login
 			return $check;
 		}
 
-		$pwndhash = utf8_encode( strtoupper( sha1( htmlspecialchars( $password ) ) ) );
+		$pwndhash = utf8_encode( strtoupper( sha1( $password ) ) );
 		$k_anon   = substr( $pwndhash, 0, 5 );
 
 		$service_url = 'https://api.pwnedpasswords.com/range/' . $k_anon;


### PR DESCRIPTION
Fixes #1

Encoding password values before hashing meant we got invalid hashes.

Removed function so we have good data to send to the API at pwnedpasswords.com